### PR TITLE
Database Redesign and Write-Up

### DIFF
--- a/server/db/models/conversation.js
+++ b/server/db/models/conversation.js
@@ -1,22 +1,33 @@
 const { Op } = require("sequelize");
 const db = require("../db");
-const Message = require("./message");
-
 const Conversation = db.define("conversation", {});
+const User = require("./user.js");
 
 // find conversation given two user Ids
 
 Conversation.findConversation = async function (user1Id, user2Id) {
-  const conversation = await Conversation.findOne({
-    where: {
-      user1Id: {
-        [Op.or]: [user1Id, user2Id]
+  const conversation = await Conversation.findAll({
+    include: [
+      {
+        User,
+        attributes: ["id", "username", "photoUrl"],
+        through: {
+          where: {
+            id: {
+              [Op.or]: [user1Id, user2Id],
+            },
+          },
+        },
       },
-      user2Id: {
-        [Op.or]: [user1Id, user2Id]
-      }
-    }
-  });
+    ],
+  })
+    .then((conversation) => conversation)
+    .filter(
+      (conversation) =>
+        conversation.users.length === 2 &&
+        conversation.users.indexOf(user1Id) !== -1 &&
+        conversation.users.indexOf(user2Id) !== -1
+    );
 
   // return conversation or null if it doesn't exist
   return conversation;

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -4,14 +4,13 @@ const Message = require("./message");
 
 // associations
 
-User.hasMany(Conversation);
-Conversation.belongsTo(User, { as: "user1" });
-Conversation.belongsTo(User, { as: "user2" });
+User.belongsToMany(Conversation, { through: "ConversationUsers" });
+Conversation.belongsToMany(User, { through: "ConversationUsers" });
 Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
 
 module.exports = {
   User,
   Conversation,
-  Message
+  Message,
 };


### PR DESCRIPTION
Closes #4 

These changes create a many-to-many relationship between users and conversations, allowing for more than two users to participate in a conversation.

_1. What additional changes are needed to implement this feature (please keep this as a high level summary)_:
* The way conversations are found would have to be changed, to account for conversations that have more than two users. This would mostly affect the conversations API route, as it relies heavily on filtering conversations by the users that are part of the conversation. On the front-end, the search box would need to return all conversations that a user is involved in. The front-end would also require a way to create a conversation with multiple users, and possibly have the option of allowing users to be added to conversations that are currently in progress.

_2. If our app were already deployed, what steps would we need to take to move to this new feature without disrupting service for current users?_:
* Because we are using Sequelize, we can use the Sequelize CLI to write and then apply migration files to change the database schema. This also gives us a good way to revert the state of the database should something go awry. If we go this route, we can write a migration file and test whether the migration (and associated code changes) work as intended. If, after testing, we determine that everything is working properly, we can then push to production and apply the migration file. As previously mentioned, the migrations file allows us to revert the schema update if we find a bug or problem in production that was missed in testing. If this did happen, we can revert the code push and migration at the same time, returning us to the last stable state.

* Another option is to create a new database with the updated schema and modify the data access code so we control what database is being read from and/or written to. Then we can slowly integrate the new database in production by first checking if writes to both databases are working as expected, still using the old database as the main data store. If this is successful, we can then begin reading from both databases, keeping the old database as the primary database while testing whether reads from the new database are successful. If all goes well, we can migrate data from the old to the new database to ensure consistency, and then begin to rely more and more on the new database, while the old database stays in reserve, until we are only using the new database. (This is the method Wix has used, as outlined in this article and talk: https://www.aviransplace.com/post/safe-database-migration-pattern-without-downtime-1. By no means is this the only way, but I would recommend this method because it is a measured approach that allows us to ensure things are working correctly before fully implementing the change.)